### PR TITLE
Set up linting VimL scripts

### DIFF
--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,5 @@
+cmdargs:
+  env:
+    neovim: true
+  severity: style_problem
+  color: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: lint
+
+vimfiles := $(shell git ls-files *.vim)
+
+lint:
+	vint $(vimfiles)

--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ While in NVIM, execute regularly:
     :PlugUpdate
 
 In Tmux, execute `prefix` + <kbd>U</kbd> regularly.
+
+## Linting VimL scripts
+
+Vimscript files can be linted using [Vint](https://github.com/Vimjas/vint). Install the linter using:
+
+    pip install --pre vim-vint
+
+Then, lint all VimL files with `make lint`.

--- a/nvim/ftdetect/json.vim
+++ b/nvim/ftdetect/json.vim
@@ -1,1 +1,2 @@
+" vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufRead composer.lock set filetype=json

--- a/nvim/ftdetect/markdown.vim
+++ b/nvim/ftdetect/markdown.vim
@@ -1,2 +1,3 @@
+" vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufRead *.MD set filetype=markdown
 autocmd BufNewFile,BufRead *.apib set filetype=markdown

--- a/nvim/ftdetect/php.vim
+++ b/nvim/ftdetect/php.vim
@@ -1,1 +1,2 @@
+" vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufRead .php_cs,.php_cs.dist set filetype=php

--- a/nvim/ftdetect/sh.vim
+++ b/nvim/ftdetect/sh.vim
@@ -1,1 +1,2 @@
+" vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufRead .env.dist,.env.example set filetype=sh

--- a/nvim/ftdetect/xml.vim
+++ b/nvim/ftdetect/xml.vim
@@ -1,1 +1,2 @@
+" vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufRead *.xml.dist set filetype=xml

--- a/nvim/ftdetect/yaml.vim
+++ b/nvim/ftdetect/yaml.vim
@@ -1,2 +1,3 @@
+" vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufRead *.yaml.dist,*.yaml.example set filetype=yaml
 autocmd BufNewFile,BufRead *.yml.dist,*.yml.example set filetype=yaml

--- a/nvim/ftplugin/gitcommit.vim
+++ b/nvim/ftplugin/gitcommit.vim
@@ -1,3 +1,5 @@
+scriptencoding utf-8
+
 " Vim already sets a text width of 72.
 setlocal colorcolumn=+1
 

--- a/nvim/ftplugin/markdown.vim
+++ b/nvim/ftplugin/markdown.vim
@@ -1,4 +1,7 @@
 setlocal spell
 
-" Disable spellcheck for API Blueprint files.
-autocmd BufEnter *.apib setlocal nospell
+augroup markdown
+    autocmd!
+    " Disable spellcheck for API Blueprint files.
+    autocmd BufEnter *.apib setlocal nospell
+augroup END

--- a/nvim/ftplugin/php.vim
+++ b/nvim/ftplugin/php.vim
@@ -5,8 +5,11 @@ setlocal colorcolumn=121
 setlocal suffixesadd+=.php
 setlocal includeexpr=substitute(v:fname,'^/','','')
 
-" Colour column 81 only for PHP source files and tests.
-autocmd BufEnter */{app,domain,src,tests}/*.php setlocal colorcolumn=+1,121
+augroup php
+    autocmd!
+    " Colour column 81 only for PHP source files and tests.
+    autocmd BufEnter */{app,domain,src,tests}/*.php setlocal colorcolumn=+1,121
+augroup END
 
 " Configure ALE.
 let b:ale_linters = ['php']

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -7,6 +7,7 @@ let s:vim_plug_script = s:nvim_config_root . '/autoload/plug.vim'
 if empty(glob(s:vim_plug_script))
     execute '!curl -fLo ' . shellescape(s:vim_plug_script) . ' --create-dirs '
         \ . 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+    " vint: next-line -ProhibitAutocmdWithNoGroup
     autocmd VimEnter * PlugInstall --sync | source $MYVIMRC
 endif
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -1,3 +1,5 @@
+scriptencoding utf-8
+
 let s:nvim_config_root = $HOME . '/.config/nvim'
 let s:load_line_plugins = 0
 


### PR DESCRIPTION
In the light of "configuration as code", let's configure a linter for VimL (Vimscript) files and fix any issues currently present in them.