### PR TITLE
Set up TypeScript (+ React) highlighting and navigation

### DIFF
--- a/nvim/ftplugin/typescriptreact.vim
+++ b/nvim/ftplugin/typescriptreact.vim
@@ -1,0 +1,1 @@
+call ApplyCocDefinitionMappings()

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -68,6 +68,7 @@ Plug 'sniphpets/sniphpets'
 
 " JavaScript.
 Plug 'pangloss/vim-javascript'
+Plug 'HerringtonDarkholme/yats.vim'
 Plug 'maxmellon/vim-jsx-pretty'
 
 " Other syntax.

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -66,9 +66,11 @@ Plug 'sniphpets/sniphpets'
     Plug 'sniphpets/sniphpets-common'
     Plug 'sniphpets/sniphpets-phpunit'
 
-" Other syntax.
+" JavaScript.
 Plug 'pangloss/vim-javascript'
 Plug 'maxmellon/vim-jsx-pretty'
+
+" Other syntax.
 Plug 'lumiliet/vim-twig'
 
 call plug#end()


### PR DESCRIPTION
Install TypeScript (+ React) syntax highlighting and define mappings for jumping to definitions using coc.nvim.