### PR TITLE
Mute ctags "ignoring null tag in" warnings for JavaScript files

### DIFF
--- a/shell.functions.sh
+++ b/shell.functions.sh
@@ -9,3 +9,9 @@ ls() {
     fi
     command ls --color "$@"
 }
+
+ctags() {
+    command ctags "$@" 2> >(
+        grep -Ev "^ctags: Warning: ignoring null tag in .+\.js\(line: .+\)$"
+    )
+}


### PR DESCRIPTION
This warning being generated a lot is a known issue for JavaScript files and seems to be related to object destructuring.

The new `ctags` function takes precedence over the `ctags` executable, runs the actual `ctags` binary but filters its stderr output for the specific warnings being thrown for JavaScript files.