### PR TITLE
Improve formatting for git commits

### DIFF
--- a/nvim/ftplugin/gitcommit.vim
+++ b/nvim/ftplugin/gitcommit.vim
@@ -4,6 +4,4 @@ scriptencoding utf-8
 setlocal colorcolumn=+1
 
 setlocal spell
-
-" Don't add character for trailing space.
-setlocal listchars=tab:→\ ,extends:»,precedes:«,nbsp:·
+setlocal nolist

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -292,7 +292,10 @@ let g:pdv_template_dir = s:nvim_config_root . '/pdv-templates'
 let g:sniphpets_common_disable_shortcuts = 1
 
 " Configure EditorConfig.
-let g:EditorConfig_exclude_patterns = ['fugitive://.*']
+let g:EditorConfig_exclude_patterns = [
+    \ 'fugitive://.*',
+    \ '.git/COMMIT_EDITMSG'
+\ ]
 
 " Configure highlightedyank.
 let g:highlightedyank_highlight_duration = 750


### PR DESCRIPTION
Improve formatting for git commits by disabling EditorConfig and no longer showing list characters on git commit message files.