### PR TITLE
Optimize tmux window/pane workflow

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -16,6 +16,8 @@ set -g base-index 1
 set -g automatic-rename on
 set -g automatic-rename-format '#{b:pane_current_path} #{pane_current_command}'
 set -g display-time 0
+set -g main-pane-height 25
+set -g other-pane-height 15
 
 # Activity.
 set -g monitor-activity off

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -27,7 +27,7 @@ set -g bell-action current
 bind -r H swap-window -d -t -1
 bind -r L swap-window -d -t +1
 bind R move-window -r
-bind c new-window -c '#{pane_current_path}'
+bind C new-window -c '#{pane_current_path}'
 bind '"' split-window -b -c '#{pane_current_path}'
 bind % split-window -b -h -c '#{pane_current_path}'
 bind C-l send-keys 'C-l'

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -8,6 +8,7 @@ set -g set-titles on
 set -g set-titles-string '#T'
 set -g mouse off
 set -g history-limit 50000
+set -g repeat-time 750
 
 # Status/panes.
 set -g status-position top


### PR DESCRIPTION
Minor improvements for optimizing the workflow with tmux windows and panes.

- Bind prefix + `C` to create new window with current pane's path
- Leverage `main-horizontal` as a common layout: set height of _other_ pane and minimum height of _main_
- Increase (binding) key repeat time