### PR TITLE
Rebind keys for moving windows

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -27,8 +27,8 @@ set -g activity-action none
 set -g bell-action current
 
 # Keybindings.
-bind -r H swap-window -d -t -1
-bind -r L swap-window -d -t +1
+bind -r M-h swap-window -d -t -1
+bind -r M-l swap-window -d -t +1
 bind R move-window -r
 bind C new-window -c '#{pane_current_path}'
 bind '"' split-window -b -c '#{pane_current_path}'


### PR DESCRIPTION
Use Alt + `h` and `l` instead of `H` and `L`. The latter is already bound to jump to the previous active session, which is a binding I want to use.