### PR TITLE
Fix `echo -n` malfunction on Mac OS X

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -12,7 +12,7 @@
 	master = "!git checkout master && git pull && git gone-remove"
 	merged = branch -a --merged
 	no-merged = branch -a --no-merged
-	setuser = "!f() { echo -n 'Email address: ' && read email && git config user.name 'Dietrich Moerman' && git config user.email $email; }; f"
+	setuser = "!f() { printf 'Email address: ' && read email && git config user.name 'Dietrich Moerman' && git config user.email $email; }; f"
 	st = status -sb
 [push]
 	default = current

--- a/.tigrc
+++ b/.tigrc
@@ -8,4 +8,4 @@ color title-focus black cyan
 color title-blur black cyan
 
 # Keybindings.
-bind generic I !@sh -c "echo -n %(commit) | copy-to-clipboard.sh"
+bind generic I !@bash -c "echo -n %(commit) | copy-to-clipboard.sh"


### PR DESCRIPTION
In cases where `echo -n` is used, either run using Bash or switch to `printf` instead.

Fixes #18.