### PR TITLE
Enable Tmux pane border titles

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -17,6 +17,8 @@ set -g base-index 1
 set -g display-time 0
 set -g main-pane-height 25
 set -g other-pane-height 15
+set -g pane-border-format '#{b:pane_current_path} #{pane_current_command}'
+set -g pane-border-status top
 set -g status-interval 5
 set -g status-position top
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -11,14 +11,14 @@ set -g history-limit 50000
 set -g repeat-time 750
 
 # Status/panes.
-set -g status-position top
-set -g status-interval 5
-set -g base-index 1
 set -g automatic-rename on
 set -g automatic-rename-format '#{b:pane_current_path} #{pane_current_command}'
+set -g base-index 1
 set -g display-time 0
 set -g main-pane-height 25
 set -g other-pane-height 15
+set -g status-interval 5
+set -g status-position top
 
 # Activity.
 set -g monitor-activity off


### PR DESCRIPTION
Relatively a new feature in Tmux, I'm enabling pane border titles to be able to easily distinguish what command is running in different panes.

This does take up space when there is only one pane in the current window, and it doesn't seem possible (yet) to hide it in that case, but let's see whether this turns out annoying.