### PR TITLE
Generate tags for Python source files

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -2,5 +2,5 @@
 --exclude=.git
 --exclude=node_modules
 --links=no
---languages=php,javascript,go,vim
+--languages=php,javascript,go,vim,python
 --php-kinds=-av


### PR DESCRIPTION
Let Universal Ctags generate tags for Python files.