### PR TITLE
Disable ligatures in iTerm2

### DIFF
--- a/iterm2.json
+++ b/iterm2.json
@@ -1,5 +1,5 @@
 {
-  "ASCII Ligatures" : true,
+  "ASCII Ligatures" : false,
   "Working Directory" : "\/Users\/dietrich",
   "Prompt Before Closing 2" : false,
   "Selected Text Color" : {


### PR DESCRIPTION
This causes significant slowness because it forces iTerm to use a slower renderer and totally disables GPU rendering.

Perhaps I need to check for a different terminal application with better ligature support.