### PR TITLE
Increase iTerm2 vertical spacing to 1.1

### DIFF
--- a/iterm2.json
+++ b/iterm2.json
@@ -318,7 +318,7 @@
   },
   "AWDS Pane Directory" : "",
   "Blur" : false,
-  "Vertical Spacing" : 1,
+  "Vertical Spacing" : 1.1000000000000001,
   "Normal Font" : "JetBrainsMono-Regular 14",
   "Ansi 7 Color" : {
     "Red Component" : 0.8784313725490196,


### PR DESCRIPTION
This fits JetBrains Mono better.