### PR TITLE
Configure linters per project

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -7,6 +7,7 @@ FirePHPCore/
 *~
 tags
 !tags/
+.lvimrc
 .ctags.d/*.ctags
 .padawan/
 .phpactor.yml

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ In Tmux, execute `prefix` + <kbd>U</kbd> regularly.
 
 Some projects require or can benefit from some custom configuration for some of the tools used in this development set-up.
 
+### Neovim
+
+Project local configuration can be set in `.lvimrc`. This allows for example to alter the set and configuration of linters being used by ALE:
+
+```viml
+let g:ale_linters = {
+    \ 'php': ['php']
+\ }
+let g:ale_php_php_executable = '/usr/local/bin/php'
+```
+
 ### universal-ctags
 
 Aside from common global configuration options set in `.ctags`, additional project-level parameters can be defined within `.ctags.d/*.ctags` files. This allows to exclude i.e. compiled or vendor source files using more `--exclude=` options.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
  * Node >= 8.10.0
  * Yarn
  * Neovim with Python extensions
- * PHP 7 (accessible at `/usr/local/bin/php`)
+ * PHP 7
  * Composer
  * universal-ctags
  * [EditorConfig](http://editorconfig.org/) `editorconfig-core-c`

--- a/nvim/ftplugin/php.vim
+++ b/nvim/ftplugin/php.vim
@@ -14,9 +14,6 @@ augroup php
     autocmd BufEnter */{app,domain,src,tests}/*.php setlocal colorcolumn=+1,121
 augroup END
 
-" Configure ALE.
-let b:ale_linters = ['php']
-
 " Expand spaces and CRs in matching braces.
 let b:delimitMate_expand_space = 1
 let b:delimitMate_expand_cr = 1

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -155,9 +155,6 @@ let g:php_manual_online_search_shortcut = ''
 let g:php_namespace_sort_after_insert = 1
 let g:PHP_noArrowMatching = 1
 
-" Configure Phpactor.
-let g:phpactorPhpBin = '/usr/local/bin/php'
-
 " Configure Semshi.
 let g:semshi#error_sign = v:false
 
@@ -166,7 +163,6 @@ let g:ale_lint_on_enter = 0
 let g:ale_lint_on_text_changed = 'never'
 let g:ale_sign_error = '✘'
 let g:ale_sign_warning = '▲'
-let g:ale_php_php_executable = '/usr/local/bin/php'
 
 " Configure Airline.
 let g:airline_powerline_fonts = 1

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -19,6 +19,7 @@ Plug 'junegunn/fzf', {'do': './install --all'}
 Plug 'Shougo/defx.nvim'
 Plug 'liuchengxu/vista.vim'
 Plug 'christoomey/vim-tmux-navigator'
+Plug 'embear/vim-localvimrc'
 
 " UI and colours.
 Plug 'chriskempson/base16-vim'

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -142,6 +142,9 @@ nnoremap <silent> <Leader>ft :Defx `expand('%:p:h')`
     \ -winwidth=45
     \ -direction=topleft<CR>
 
+" Configure Localvimrc.
+let g:localvimrc_persistent = 1
+
 " Configure NERDCommenter.
 let g:NERDDefaultAlign = 'left'
 


### PR DESCRIPTION
Allowing project local Neovim configuration, some settings tailored to a specific project can be removed from the global settings. I.e. limiting the PHP linters run by ALE and the hardcoded path to the PHP binary.