### PR TITLE
Fix PHP files with PHP-CS-Fixer using custom fixer

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -18,3 +18,4 @@ local.settings.php
 www/sites/*.local
 www/sites/*.local.*
 settings.local.php
+*.ale-php-cs-fixer

--- a/nvim/ftplugin/php_fixer.vim
+++ b/nvim/ftplugin/php_fixer.vim
@@ -1,0 +1,25 @@
+function! AlePhpCsFixerTempFile(buffer) abort
+    return bufname(a:buffer) . '.ale-php-cs-fixer'
+endfunction
+
+function! AlePhpCsFixer(buffer) abort
+    let l:temporary_file = AlePhpCsFixerTempFile(a:buffer)
+    let l:lines = getbufline(a:buffer, 1, '$')
+    call ale#util#Writefile(a:buffer, l:lines, l:temporary_file)
+
+    return {
+        \ 'command': 'php-cs-fixer fix ' . shellescape(l:temporary_file),
+        \ 'process_with': 'AleProcessPhpCsFixer',
+        \ 'read_buffer': 0,
+    \ }
+endfunction
+
+function! AleProcessPhpCsFixer(buffer, output) abort
+    let l:temporary_file = AlePhpCsFixerTempFile(a:buffer)
+    let l:lines = readfile(l:temporary_file)
+    call delete(l:temporary_file)
+
+    return l:lines
+endfunction
+
+let b:ale_fixers = ['AlePhpCsFixer']


### PR DESCRIPTION
The built-in ALE fixer using PHP-CS-Fixer works with temporary files. This does not work when using a Docker development environment where the fixer is running in a tailored container.

This custom fixer callback creates a temporary copy of the current file in the working directory, runs `php-cs-fixer fix` on the file using a relative path, then feeds the result back to the buffer, deleting the copy.

Closes #5.