### PR TITLE
More ALE tweaks

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -162,6 +162,7 @@ let g:semshi#error_sign = v:false
 let g:ale_lint_on_enter = 0
 let g:ale_list_window_size = 3
 let g:ale_open_list = 1
+let g:ale_sign_column_always = 1
 let g:ale_sign_error = '✘'
 let g:ale_sign_warning = '▲'
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -165,6 +165,10 @@ let g:ale_open_list = 1
 let g:ale_sign_column_always = 1
 let g:ale_sign_error = '✘'
 let g:ale_sign_warning = '▲'
+augroup ale
+    autocmd!
+    autocmd QuitPre * if empty(&buftype) | lclose | endif
+augroup END
 
 " Configure Airline.
 let g:airline_powerline_fonts = 1

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -160,7 +160,6 @@ let g:semshi#error_sign = v:false
 
 " Configure ALE.
 let g:ale_lint_on_enter = 0
-let g:ale_lint_on_text_changed = 'never'
 let g:ale_list_window_size = 3
 let g:ale_open_list = 1
 let g:ale_sign_error = '✘'


### PR DESCRIPTION
Reintroducing linting after every text change (when returning to normal mode). Also keeping the sign column visible and closing the buffer's location list automatically.