### PR TITLE
Open ALE location list only on buffer save

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -162,7 +162,7 @@ let g:semshi#mark_selected_nodes = 0
 " Configure ALE.
 let g:ale_lint_on_enter = 0
 let g:ale_list_window_size = 3
-let g:ale_open_list = 1
+let g:ale_open_list = 'on_save'
 let g:ale_sign_column_always = 1
 let g:ale_sign_error = '✘'
 let g:ale_sign_warning = '▲'


### PR DESCRIPTION
It seems opening the location list switches modes (or a similar operation) that makes it impossible to complete UltiSnips snippets and cycle to next/previous variables.

Since this is an essential part of my workflow, I change ALE to only open the loclist when saving, but keep linting active when returning to normal mode.