### PR TITLE
Test runner improvements

### DIFF
--- a/nvim/autoload/test_runner.vim
+++ b/nvim/autoload/test_runner.vim
@@ -25,7 +25,7 @@ function! test_runner#Run(current_test) abort
         return
     endif
 
-    let l:command .= ' ' . l:filter_arg . ' ' . l:current_test_name
+    let l:command .= ' ' . l:filter_arg . l:current_test_name
 
     call VimuxRunCommand(l:command)
 endfunction

--- a/nvim/autoload/test_runner.vim
+++ b/nvim/autoload/test_runner.vim
@@ -37,3 +37,7 @@ endfunction
 function! test_runner#RunTest() abort
     call test_runner#Run(v:true)
 endfunction
+
+function! test_runner#ReRun() abort
+    call VimuxRunLastCommand()
+endfunction

--- a/nvim/ftplugin/gitcommit.vim
+++ b/nvim/ftplugin/gitcommit.vim
@@ -3,3 +3,5 @@ setlocal colorcolumn=+1
 
 setlocal spell
 setlocal nolist
+
+let b:ale_linters = []

--- a/nvim/ftplugin/php.vim
+++ b/nvim/ftplugin/php.vim
@@ -20,7 +20,7 @@ let b:delimitMate_expand_cr = 1
 
 " Configure test runner.
 let b:test_runner_executable = 'phpunit'
-let b:test_runner_filter_arg = '--filter'
+let b:test_runner_filter_arg = '--filter='
 
 call ApplyCocDefinitionMappings()
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -371,6 +371,7 @@ nnoremap <silent> <Leader>Pc :let @+ = @% . ":" . line(".")<CR>
 " Test runner mappings.
 nnoremap <silent> <Leader>rc :call test_runner#RunCase()<CR>
 nnoremap <silent> <Leader>rt :call test_runner#RunTest()<CR>
+nnoremap <silent> <Leader>rr :call test_runner#ReRun()<CR>
 
 " Use arrow keys for resizing splits.
 nnoremap <silent> <Up>    :resize +1<CR>


### PR DESCRIPTION
Some small improvements such as not hardcoding a space after the filter argument, and rerunning the last test using `<Space>rr`.