### PR TITLE
Improve API Blueprint support

### DIFF
--- a/nvim/ftdetect/markdown.vim
+++ b/nvim/ftdetect/markdown.vim
@@ -1,3 +1,2 @@
 " vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufRead *.MD set filetype=markdown
-autocmd BufNewFile,BufRead *.apib set filetype=markdown

--- a/nvim/ftplugin/markdown.vim
+++ b/nvim/ftplugin/markdown.vim
@@ -1,7 +1,1 @@
 setlocal spell
-
-augroup markdown
-    autocmd!
-    " Disable spellcheck for API Blueprint files.
-    autocmd BufEnter *.apib setlocal nospell
-augroup END

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -243,6 +243,7 @@ let g:vista#renderer#enable_icon = 0
 let g:vista_close_on_jump = 1
 let g:vista_echo_cursor = 0
 let g:vista_executive_for = {
+    \ 'apiblueprint': 'markdown',
     \ 'go': 'coc',
     \ 'markdown': 'toc',
     \ 'php': 'coc',

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -17,7 +17,7 @@ call plug#begin()
 Plug 'junegunn/fzf', {'do': './install --all'}
     Plug 'junegunn/fzf.vim'
 Plug 'Shougo/defx.nvim'
-Plug 'dietrichm/vista.vim', {'branch': 'support-apiblueprint'}
+Plug 'liuchengxu/vista.vim'
 Plug 'christoomey/vim-tmux-navigator'
 Plug 'embear/vim-localvimrc'
 Plug 'benmills/vimux'

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -79,6 +79,7 @@ Plug 'Vimjas/vim-python-pep8-indent'
 
 " Other syntax.
 Plug 'lumiliet/vim-twig'
+Plug 'kylef/apiblueprint.vim'
 
 call plug#end()
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -17,7 +17,7 @@ call plug#begin()
 Plug 'junegunn/fzf', {'do': './install --all'}
     Plug 'junegunn/fzf.vim'
 Plug 'Shougo/defx.nvim'
-Plug 'liuchengxu/vista.vim'
+Plug 'dietrichm/vista.vim', {'branch': 'support-apiblueprint'}
 Plug 'christoomey/vim-tmux-navigator'
 Plug 'embear/vim-localvimrc'
 Plug 'benmills/vimux'


### PR DESCRIPTION
Going back to installing the API Blueprint vim plug-in to have a dedicated filetype and linting through ALE.

Also fixing vista.vim in a [forked version](https://github.com/dietrichm/vista.vim/tree/support-apiblueprint) of the plug-in, so a correct TOC is rendered in the sidebar.