### PR TITLE
Use backslash for toggling search highlighting

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -333,15 +333,6 @@ nnoremap <silent> g# :setlocal hlsearch \| :normal! g#<CR>
 " Toggle search highlight.
 nnoremap <silent> \ :setlocal hlsearch!<CR>
 
-" Disable search highlight and reload signs using CR.
-nnoremap <silent> <CR> :setlocal nohlsearch \| :SignifyRefresh<CR>
-augroup carriage_return
-    autocmd!
-    " Except for in the quickfix and command line window.
-    autocmd BufReadPost quickfix nnoremap <buffer> <CR> <CR>
-    autocmd CmdwinEnter * nnoremap <buffer> <CR> <CR>
-augroup END
-
 " Paragraph motions do not change jumplist.
 nnoremap <silent> } :keepjumps normal! }<CR>
 nnoremap <silent> { :keepjumps normal! {<CR>

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -330,8 +330,8 @@ nnoremap <silent> # :setlocal hlsearch \| :normal! #<CR>
 nnoremap <silent> g* :setlocal hlsearch \| :normal! g*<CR>
 nnoremap <silent> g# :setlocal hlsearch \| :normal! g#<CR>
 
-" Enable search highlight manually.
-nnoremap <silent> \ :setlocal hlsearch<CR>
+" Toggle search highlight.
+nnoremap <silent> \ :setlocal hlsearch!<CR>
 
 " Disable search highlight and reload signs using CR.
 nnoremap <silent> <CR> :setlocal nohlsearch \| :SignifyRefresh<CR>


### PR DESCRIPTION
Removing custom keybindings on CR since the manual Signify signs refresh was no longer needed, and `\` is now mapped to toggle `hlsearch`.