### PR TITLE
Improve Tmux terminal capabilities with correct terminfo

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,6 +1,6 @@
 # Terminal behaviour.
 set -sg escape-time 0
-set -g default-terminal "screen-256color"
+set -g default-terminal 'tmux-256color'
 set -g focus-events on
 
 # Generic.
@@ -43,7 +43,6 @@ bind -r Left resize-pane -L 2
 bind -r Right resize-pane -R 2
 
 # Theme.
-set-option -sa terminal-overrides ',xterm-256color:RGB'
 source-file $MY_CONFIG_ROOT/.tmuxline.conf
 
 # Plugins.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ tic tmux-256color.terminfo
 
 While in NVIM, execute regularly:
 
-    :PlugUpgrade
-    :PlugUpdate
+```
+:PlugUpgrade
+:PlugUpdate
+```
 
 In Tmux, execute `prefix` + <kbd>U</kbd> regularly.
 
@@ -84,6 +86,8 @@ composer.autoloader_path: %project_root%/dependencies/autoload.php
 
 Vimscript files can be linted using [Vint](https://github.com/Vimjas/vint). Install the linter using:
 
-    pip3 install --pre vim-vint
+```shell
+pip3 install --pre vim-vint
+```
 
 Then, lint all VimL files with `make lint`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ The kitty configuration relies on [JetBrains Mono](https://github.com/JetBrains/
  * Execute `config-install.sh`.
  * In Tmux, execute `prefix` + <kbd>I</kbd>.
 
+On Mac OS X, the following might be necessary to have correct terminal capabilities in Tmux:
+
+```shell
+brew install ncurses
+/usr/local/opt/ncurses/bin/infocmp tmux-256color > tmux-256color.terminfo
+tic tmux-256color.terminfo
+```
+
 ### Updating
 
 While in NVIM, execute regularly:

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -131,6 +131,9 @@ highlight SpellRare ctermfg=0
 highlight goCoverageCovered ctermfg=lightcyan
 highlight goCoverageUncover ctermfg=red
 
+" Comments are rendered in italic.
+highlight Comment cterm=italic
+
 " Configure netrw.
 let g:netrw_banner = 0
 let g:netrw_bufsettings = 'noma nomod nonu nowrap ro nobl nolist'

--- a/shell.aliases.sh
+++ b/shell.aliases.sh
@@ -1,2 +1,3 @@
 alias largest='du -hsx * | sort -rh | head -15'
 alias rgi='rg --ignore-vcs'
+alias tig='TERM=xterm tig'


### PR DESCRIPTION
This enables us to render comments with italic text in Neovim running in Tmux.