### PR TITLE
Remove Neovim undodir from repository

### DIFF
--- a/nvim/.gitignore
+++ b/nvim/.gitignore
@@ -2,4 +2,3 @@ plugged/
 .netrwhist
 autoload/plug.vim*
 spell/
-undodir/

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -112,9 +112,6 @@ set shortmess+=cIW
 set spelllang=en_gb
 set path=.,**2
 set grepprg=rg\ --vimgrep
-
-" Persistent undo.
-let &undodir = s:nvim_config_root . '/undodir'
 set undofile
 
 " Colours


### PR DESCRIPTION
Set the location of `undodir` back to the default one, which on Linux is `~/.local/share/nvim/undo/`.

This removes the need to keep `nvim/undodir/` as an ignored directory.