### PR TITLE
Execute Python linters through pipenv

### DIFF
--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -1,4 +1,6 @@
 setlocal textwidth=79
 setlocal colorcolumn=+1
 
+let b:ale_python_auto_pipenv = 1
+
 call ApplyCocDefinitionMappings()


### PR DESCRIPTION
This avoids having to start a pipenv shell for Neovim in order to find linters installed in the virtualenv.