### PR TITLE
Configure key bindings for Python files

### DIFF
--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -12,3 +12,8 @@ call ApplyCocDefinitionMappings()
 
 nmap <silent> <buffer> <Leader>rn <Plug>(coc-rename)
 nnoremap <silent> <buffer> <Leader>si :call CocAction('runCommand', 'python.sortImports')<CR>
+
+" Searching using ripgrep.
+nnoremap <silent> <buffer> <Leader>sce :execute "Rg \\bclass .+\\(.*\\b" . expand("<cword>") . "\\b.*\\)"<CR>
+nnoremap <silent> <buffer> <Leader>sci :execute "Rg \\b" . expand("<cword>") . "\\("<CR>
+nnoremap <silent> <buffer> <Leader>smc :execute "Rg \\." . expand("<cword>") . "\\b"<CR>


### PR DESCRIPTION
Most of these are based on the equally named ones for PHP but with adapted regular expressions.