### PR TITLE
Retire macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dotfiles
 
+These dotfiles are being used and hence tested only on GNU/Linux. MacOS is no longer supported.
+
 ## Dependencies
 
  * [kitty](https://sw.kovidgoyal.net/kitty/)

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -3,8 +3,6 @@
 # Generic.
 cursor_blink_interval 0
 mouse_hide_wait -1
-macos_option_as_alt left
-macos_show_window_title_in window
 
 # Fonts.
 font_family         JetBrains Mono Regular
@@ -13,7 +11,6 @@ italic_font         JetBrains Mono Italic
 bold_italic_font    JetBrains Mono Bold Italic
 font_size           14.0
 adjust_line_height  115%
-macos_thicken_font  0.2
 
 # Activity.
 enable_audio_bell no
@@ -25,7 +22,6 @@ map ctrl+shift+minus change_font_size all -1.0
 
 # Theme.
 include base16-bright.conf
-macos_titlebar_color background
 
 # Machine specific config file.
 include local.conf

--- a/shell.aliases.sh
+++ b/shell.aliases.sh
@@ -1,2 +1,3 @@
 alias largest='du -hsx * | sort -rh | head -15'
+alias ls='ls --color=auto'
 alias rgi='rg --ignore-vcs'

--- a/shell.functions.sh
+++ b/shell.functions.sh
@@ -2,14 +2,6 @@ precmd() {
     echo -ne "\033]0;${PWD/#$HOME/~}\007"
 }
 
-ls() {
-    if [ "$OSTYPE" != "linux-gnu" ]; then
-        command ls "$@"
-        return $?
-    fi
-    command ls --color "$@"
-}
-
 ctags() {
     command ctags "$@" 2> >(
         grep -Ev "^ctags: Warning: ignoring null tag in .+\.js\(line: .+\)$"


### PR DESCRIPTION
I'm no longer using these dotfiles on macOS.

Also fixing a (redundant) function definition name clash with an already defined alias on Fedora 32.