### PR TITLE
Detect presence of `Pipfile.lock` to run tests through pipenv

### DIFF
--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -8,7 +8,11 @@ let b:delimitMate_expand_cr = 1
 let b:delimitMate_expand_space = 1
 
 " Configure test runner.
-let b:test_runner_executable = 'pipenv run pytest'
+if empty(findfile('Pipfile.lock'))
+    let b:test_runner_executable = 'pytest'
+else
+    let b:test_runner_executable = 'pipenv run pytest'
+endif
 let b:test_runner_filter_arg = '-k '
 
 call ApplyCocDefinitionMappings()


### PR DESCRIPTION
Do not run `pytest` using `pipenv` when no `Pipfile.lock` is present.