### PR TITLE
Update test runner plugin to use `file` and `test` replacement strings

### DIFF
--- a/nvim/autoload/test_runner.vim
+++ b/nvim/autoload/test_runner.vim
@@ -1,41 +1,34 @@
-function! test_runner#Run(current_test) abort
-    let l:executable = get(b:, 'test_runner_executable', '')
-    let l:filter_arg = get(b:, 'test_runner_filter_arg', '')
-    let l:current_test_name = get(b:, 'coc_current_function', '')
+function! test_runner#RunCase() abort
+    let l:executable = get(b:, 'test_runner_executable_case', '')
 
     if empty(l:executable)
-        echomsg 'No executable configured.'
+        echomsg 'No case executable configured.'
         return
     endif
 
-    let l:command = l:executable . ' ' . bufname('%')
-
-    if a:current_test == v:false
-        call VimuxRunCommand(l:command)
-        return
-    endif
-
-    if empty(l:filter_arg)
-        echomsg 'No filter argument configured.'
-        return
-    endif
-
-    if empty(l:current_test_name)
-        echomsg 'No function found under cursor.'
-        return
-    endif
-
-    let l:command .= ' ' . l:filter_arg . l:current_test_name
+    let l:command = substitute(l:executable, '{file}', bufname('%'), 'g')
 
     call VimuxRunCommand(l:command)
 endfunction
 
-function! test_runner#RunCase() abort
-    call test_runner#Run(v:false)
-endfunction
-
 function! test_runner#RunTest() abort
-    call test_runner#Run(v:true)
+    let l:executable = get(b:, 'test_runner_executable_test', '')
+    let l:test_name = get(b:, 'coc_current_function', '')
+
+    if empty(l:executable)
+        echomsg 'No test executable configured.'
+        return
+    endif
+
+    if empty(l:test_name)
+        echomsg 'No function found under cursor.'
+        return
+    endif
+
+    let l:command = substitute(l:executable, '{file}', bufname('%'), 'g')
+    let l:command = substitute(l:command, '{test}', l:test_name, 'g')
+
+    call VimuxRunCommand(l:command)
 endfunction
 
 function! test_runner#ReRun() abort

--- a/nvim/ftplugin/php.vim
+++ b/nvim/ftplugin/php.vim
@@ -19,8 +19,8 @@ let b:delimitMate_expand_space = 1
 let b:delimitMate_expand_cr = 1
 
 " Configure test runner.
-let b:test_runner_executable = 'phpunit'
-let b:test_runner_filter_arg = '--filter='
+let b:test_runner_executable_case = 'phpunit {file}'
+let b:test_runner_executable_test = 'phpunit {file} --filter={test}'
 
 call ApplyCocDefinitionMappings()
 

--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -9,11 +9,12 @@ let b:delimitMate_expand_space = 1
 
 " Configure test runner.
 if !empty(findfile('Pipfile.lock'))
-    let b:test_runner_executable = 'pipenv run pytest'
+    let b:test_runner_executable_case = 'pipenv run pytest {file}'
+    let b:test_runner_executable_test = 'pipenv run pytest {file} -k {test}'
 else
-    let b:test_runner_executable = 'pytest'
+    let b:test_runner_executable_case = 'pytest {file}'
+    let b:test_runner_executable_test = 'pytest {file} -k {test}'
 endif
-let b:test_runner_filter_arg = '-k '
 
 call ApplyCocDefinitionMappings()
 

--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -8,10 +8,10 @@ let b:delimitMate_expand_cr = 1
 let b:delimitMate_expand_space = 1
 
 " Configure test runner.
-if empty(findfile('Pipfile.lock'))
-    let b:test_runner_executable = 'pytest'
-else
+if !empty(findfile('Pipfile.lock'))
     let b:test_runner_executable = 'pipenv run pytest'
+else
+    let b:test_runner_executable = 'pytest'
 endif
 let b:test_runner_filter_arg = '-k '
 


### PR DESCRIPTION
Now we can vary the position of the file and test name in the executable config values.

Relates to #88.