### PR TITLE
Replace coc-python with coc-jedi using jedi-language-server

### DIFF
--- a/nvim/coc-settings.json
+++ b/nvim/coc-settings.json
@@ -6,8 +6,5 @@
     "list.normalMappings": {
         "v": "action:vsplit"
     },
-    "python.autoComplete.addBrackets": true,
-    "python.jediEnabled": true,
-    "python.linting.enabled": false,
-    "python.pythonPath": "python3.8"
+    "jedi.startupMessage": false
 }

--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -17,7 +17,7 @@ endif
 
 call ApplyCocDefinitionMappings()
 
-nnoremap <silent> <buffer> <Leader>si :call CocActionAsync('runCommand', 'python.sortImports')<CR>
+nnoremap <silent> <buffer> <Leader>si :Isort<CR>
 
 " Searching using ripgrep.
 nnoremap <silent> <buffer> <Leader>sce :execute "Rg \\bclass .+\\(.*\\b" . expand("<cword>") . "\\b.*\\)"<CR>

--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -1,6 +1,5 @@
 setlocal textwidth=79
 setlocal colorcolumn=+1
-setlocal formatexpr=CocAction('formatSelected')
 
 let b:ale_python_auto_pipenv = 1
 let b:ale_python_flake8_change_directory = 0

--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -18,7 +18,6 @@ endif
 
 call ApplyCocDefinitionMappings()
 
-nmap <silent> <buffer> <Leader>rn <Plug>(coc-rename)
 nnoremap <silent> <buffer> <Leader>si :call CocActionAsync('runCommand', 'python.sortImports')<CR>
 
 " Searching using ripgrep.

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -47,7 +47,7 @@ Plug 'neoclide/coc.nvim', {'do': 'yarn install --frozen-lockfile'}
     endif
     Plug 'neoclide/coc-sources', {'as': 'coc-ultisnips', 'do': 'yarn install --frozen-lockfile', 'rtp': 'packages/ultisnips'}
     Plug 'neoclide/coc-tsserver', {'do': 'yarn install --frozen-lockfile'}
-    Plug 'neoclide/coc-python', {'do': 'yarn install --frozen-lockfile'}
+    Plug 'pappasam/coc-jedi', {'do': 'yarn install --frozen-lockfile'}
     Plug 'neoclide/coc-json', {'do': 'yarn install --frozen-lockfile'}
     if s:load_go_plugins
         Plug 'josa42/coc-go', {'do': 'yarn install --frozen-lockfile'}

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -89,6 +89,7 @@ Plug 'maxmellon/vim-jsx-pretty'
 " Python.
 Plug 'numirias/semshi', {'do': ':UpdateRemotePlugins'}
 Plug 'Vimjas/vim-python-pep8-indent'
+Plug 'fisadev/vim-isort'
 
 " Other syntax.
 Plug 'lumiliet/vim-twig'

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -292,7 +292,10 @@ let g:UltiSnipsSnippetsDir = s:nvim_config_root . '/UltiSnips'
 let g:UltiSnipsEditSplit = 'context'
 
 " Configure COC.
+nmap <silent> <Leader>ca <Plug>(coc-codeaction)
+nmap <silent> <Leader>rn <Plug>(coc-rename)
 nmap <silent> <Leader>sr <Plug>(coc-references)
+xmap <silent> <Leader>ca <Plug>(coc-codeaction-selected)
 inoremap <silent> <expr> <C-Space> coc#refresh()
 nnoremap <silent> <Leader>h :call CocActionAsync('doHover')<CR>
 nnoremap <silent> <Leader>ts :echo get(b:, 'coc_current_function', '')<CR>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 neovim
 pynvim
 vim-vint >= 0.4a3
-jedi
 isort
-pipenv


### PR DESCRIPTION
Integration seems a lot better, with clear method signature popups and less CPU load when editing files.

Might be the last COC extension being installed before I switch to NVIM LSP (#77).