### PR TITLE
Support virtualenv and Conda environment

### DIFF
--- a/ctags/global.ctags
+++ b/ctags/global.ctags
@@ -5,3 +5,4 @@
 --links=no
 --languages=php,javascript,go,vim,python
 --php-kinds=-av
+--python-kinds=-v

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -359,7 +359,7 @@ nnoremap <silent> [L :lfirst<CR>
 " Searching using ripgrep.
 nnoremap <silent> <Leader>sw :execute "Rg \\b" . expand("<cword>") . "\\b"<CR>
 command! -bang -nargs=* Rgi call fzf#vim#grep(
-    \ "rg --ignore-vcs --column --line-number --no-heading --color=always --smart-case ".shellescape(<q-args>),
+    \ 'rg --ignore-vcs --column --line-number --no-heading --color=always --smart-case -- ' . shellescape(<q-args>),
     \ 1,
     \ {},
     \ <bang>0

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -120,7 +120,7 @@ set hidden
 set updatetime=250
 set shortmess+=cIW
 set spelllang=en_gb
-set path=.,**2
+set path=.,*
 set grepprg=rg\ --vimgrep
 set undofile
 

--- a/nvim/plugin/python_path.vim
+++ b/nvim/plugin/python_path.vim
@@ -11,3 +11,10 @@ if empty(s:packages)
 endif
 
 let &path .= ',' . s:packages
+
+command! -bang -nargs=* Rgp call fzf#vim#grep(
+    \ 'rg --column --line-number --no-heading --color=always --smart-case -- ' . shellescape(<q-args>),
+    \ 1,
+    \ {'dir': s:packages},
+    \ <bang>0
+\ )

--- a/nvim/plugin/python_path.vim
+++ b/nvim/plugin/python_path.vim
@@ -5,3 +5,9 @@ if !empty($VIRTUAL_ENV)
 elseif !empty($CONDA_PREFIX)
     let s:packages = glob('$CONDA_PREFIX/lib/python*/site-packages')
 endif
+
+if empty(s:packages)
+    finish
+endif
+
+let &path .= ',' . s:packages

--- a/nvim/plugin/python_path.vim
+++ b/nvim/plugin/python_path.vim
@@ -1,0 +1,7 @@
+let s:packages = ''
+
+if !empty($VIRTUAL_ENV)
+    let s:packages = glob('$VIRTUAL_ENV/lib/python*/site-packages')
+elseif !empty($CONDA_PREFIX)
+    let s:packages = glob('$CONDA_PREFIX/lib/python*/site-packages')
+endif

--- a/nvim/plugin/python_path.vim
+++ b/nvim/plugin/python_path.vim
@@ -1,3 +1,8 @@
+if exists('g:loaded_python_path')
+    finish
+endif
+
+let g:loaded_python_path = 1
 let s:packages = ''
 
 if !empty($VIRTUAL_ENV)

--- a/shell.aliases.sh
+++ b/shell.aliases.sh
@@ -1,3 +1,4 @@
+alias ctagsp='ctags . ${VIRTUAL_ENV:-$CONDA_PREFIX}/lib/python*/site-packages'
 alias largest='du -hsx * | sort -rh | head -15'
 alias ls='ls --color=auto'
 alias rgi='rg --ignore-vcs'


### PR DESCRIPTION
Improve behaviour in virtualenv or Conda environments with Python site packages.

Adding:
* ability to also index tags for site packages using `ctagsp`
* Python packages path to `path`, allowing `:find` and `gf` to take these into account
* new `:Rgp` wrapper around ripgrep to scan Python packages