### PR TITLE
Allow test filename to be transformed in test runner

### DIFF
--- a/nvim/autoload/test_runner.vim
+++ b/nvim/autoload/test_runner.vim
@@ -1,3 +1,9 @@
+function! s:PrepareCommand(executable, file) abort
+    let l:command = substitute(a:executable, '{file}', a:file, 'g')
+
+    return l:command
+endfunction
+
 function! test_runner#RunCase() abort
     let l:executable = get(b:, 'test_runner_executable_case', '')
 
@@ -6,7 +12,7 @@ function! test_runner#RunCase() abort
         return
     endif
 
-    let l:command = substitute(l:executable, '{file}', bufname('%'), 'g')
+    let l:command = s:PrepareCommand(l:executable, bufname('%'))
 
     call VimuxRunCommand(l:command)
 endfunction
@@ -25,7 +31,7 @@ function! test_runner#RunTest() abort
         return
     endif
 
-    let l:command = substitute(l:executable, '{file}', bufname('%'), 'g')
+    let l:command = s:PrepareCommand(l:executable, bufname('%'))
     let l:command = substitute(l:command, '{test}', l:test_name, 'g')
 
     call VimuxRunCommand(l:command)

--- a/nvim/autoload/test_runner.vim
+++ b/nvim/autoload/test_runner.vim
@@ -1,5 +1,6 @@
 function! s:PrepareCommand(executable, file) abort
-    let l:command = substitute(a:executable, '{file}', a:file, 'g')
+    let l:Transformer = get(b:, 'test_runner_filename_transformer', {file -> file})
+    let l:command = substitute(a:executable, '{file}', l:Transformer(a:file), 'g')
 
     return l:command
 endfunction

--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -7,7 +7,7 @@ let b:delimitMate_expand_cr = 1
 let b:delimitMate_expand_space = 1
 
 " Configure test runner.
-if !empty(findfile('Pipfile.lock'))
+if !empty(findfile('Pipfile.lock', '.;'))
     let b:test_runner_executable_case = 'pipenv run pytest {file}'
     let b:test_runner_executable_test = 'pipenv run pytest {file} -k {test}'
 else


### PR DESCRIPTION
A filetype plugin can set `b:test_runner_filename_transformer` to a Vimscript lambda that transforms a filename to for example a module name.

Closes #88.