### PR TITLE
FZF improvements

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -10,3 +10,4 @@ node_modules/
 .mypy_cache/
 __pycache__/
 .pytest_cache/
+*.dist-info/

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -273,7 +273,7 @@ nnoremap <silent> <Leader>b :Buffers<CR>
 nnoremap <silent> <Leader>fh :History<CR>
 let $FZF_DEFAULT_OPTS .= ' --reverse'
 let g:fzf_layout = {'window': {'width': 0.8, 'height': 0.6}}
-let g:fzf_preview_window = ''
+let g:fzf_preview_window = ['right:50%:hidden', 'ctrl-/']
 
 " Configure UltiSnips.
 let g:UltiSnipsSnippetsDir = s:nvim_config_root . '/UltiSnips'

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -272,7 +272,7 @@ nnoremap <silent> <Leader>o :Files<CR>
 nnoremap <silent> <Leader>b :Buffers<CR>
 nnoremap <silent> <Leader>fh :History<CR>
 let $FZF_DEFAULT_OPTS .= ' --reverse'
-let g:fzf_layout = {'window': {'width': 0.8, 'height': 0.6}}
+let g:fzf_layout = {'window': {'width': 0.8, 'height': 0.8}}
 let g:fzf_preview_window = ['right:50%:hidden', 'ctrl-/']
 
 " Configure UltiSnips.

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -271,7 +271,7 @@ nnoremap <silent> <Leader>tb :Vista<CR>
 nnoremap <silent> <Leader>o :Files<CR>
 nnoremap <silent> <Leader>b :Buffers<CR>
 nnoremap <silent> <Leader>fh :History<CR>
-let $FZF_DEFAULT_OPTS .= ' --reverse --margin 0,1'
+let $FZF_DEFAULT_OPTS .= ' --reverse'
 let g:fzf_layout = {'window': {'width': 0.8, 'height': 0.6}}
 let g:fzf_preview_window = ''
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -272,19 +272,7 @@ nnoremap <silent> <Leader>o :Files<CR>
 nnoremap <silent> <Leader>b :Buffers<CR>
 nnoremap <silent> <Leader>fh :History<CR>
 let $FZF_DEFAULT_OPTS .= ' --reverse --margin 0,1'
-function! FloatingFZF()
-    let width = float2nr(&columns * 0.8)
-    let height = float2nr(&lines * 0.6)
-    let opts = {
-        \ 'relative': 'editor',
-        \ 'row': (&lines - height) / 2,
-        \ 'col': (&columns - width) / 2,
-        \ 'width': width,
-        \ 'height': height
-    \ }
-    call nvim_open_win(nvim_create_buf(v:false, v:true), v:true, opts)
-endfunction
-let g:fzf_layout = { 'window': 'call FloatingFZF()' }
+let g:fzf_layout = {'window': {'width': 0.8, 'height': 0.6}}
 let g:fzf_preview_window = ''
 
 " Configure UltiSnips.

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -352,7 +352,7 @@ nnoremap <silent> <Leader>sw :execute "Rg \\b" . expand("<cword>") . "\\b"<CR>
 command! -bang -nargs=* Rgi call fzf#vim#grep(
     \ 'rg --ignore-vcs --column --line-number --no-heading --color=always --smart-case -- ' . shellescape(<q-args>),
     \ 1,
-    \ {},
+    \ call('fzf#vim#with_preview', g:fzf_preview_window),
     \ <bang>0
 \ )
 

--- a/nvim/plugin/python_path.vim
+++ b/nvim/plugin/python_path.vim
@@ -20,6 +20,6 @@ let &path .= ',' . s:packages
 command! -bang -nargs=* Rgp call fzf#vim#grep(
     \ 'rg --column --line-number --no-heading --color=always --smart-case -- ' . shellescape(<q-args>),
     \ 1,
-    \ {'dir': s:packages},
+    \ call('fzf#vim#with_preview', [{'dir': s:packages}] + g:fzf_preview_window),
     \ <bang>0
 \ )


### PR DESCRIPTION
- Replace custom FZF popup window with built-in one + increase height
- Enable by default hidden preview window behind `CTRL-/`
- Ignore Python `dist-info` directories in ripgrep