### PR TITLE
Configure shared gopls for vim-go and coc-go

### DIFF
--- a/nvim/coc-settings.json
+++ b/nvim/coc-settings.json
@@ -2,6 +2,7 @@
     "coc.preferences.currentFunctionSymbolAutoUpdate": true,
     "coc.preferences.extensionUpdateCheck": "never",
     "diagnostic.enable": false,
+    "go.goplsPath": "gopls",
     "list.normalMappings": {
         "v": "action:vsplit"
     },

--- a/nvim/coc-settings.json
+++ b/nvim/coc-settings.json
@@ -1,12 +1,12 @@
 {
-    "diagnostic.enable": false,
-    "suggest.autoTrigger": "always",
     "coc.preferences.currentFunctionSymbolAutoUpdate": true,
     "coc.preferences.extensionUpdateCheck": "never",
+    "diagnostic.enable": false,
     "list.normalMappings": {
         "v": "action:vsplit"
     },
-    "python.linting.enabled": false,
+    "pyright.disableOrganizeImports": true,
     "python.analysis.diagnosticMode": "workspace",
-    "pyright.disableOrganizeImports": true
+    "python.linting.enabled": false,
+    "suggest.autoTrigger": "always"
 }

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -305,6 +305,7 @@ let g:vdebug_options = {
 \ }
 
 " Configure vim-go.
+let g:go_code_completion_enabled = 0
 let g:go_def_mapping_enabled = 0
 
 " Configure splitjoin.

--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -1,4 +1,5 @@
 export MY_CONFIG_ROOT="$( cd "$( dirname "${(%):-%N}" )/.." && pwd )"
+export GOPATH=$HOME/go
 
 typeset -U path
 path=(
@@ -9,6 +10,7 @@ path=(
     $HOME/.config/yarn/global/node_modules/.bin
     $HOME/bin
     $HOME/.local/bin
+    $GOPATH/bin
     $MY_CONFIG_ROOT/bin
     /usr/local/opt/python@3.8/bin
     /usr/local/go/bin
@@ -20,7 +22,6 @@ export PATH
 export CLICOLOR=1
 export EDITOR=nvim
 export FZF_DEFAULT_COMMAND="rg --files"
-export GOPATH=$HOME/go
 export GPG_TTY=$(tty)
 export LANG=en_GB.UTF-8
 export LANGUAGE=en_GB:en

--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -1,7 +1,5 @@
-# Set my config root.
 export MY_CONFIG_ROOT="$( cd "$( dirname "${(%):-%N}" )/.." && pwd )"
 
-# Configure path.
 typeset -U path
 path=(
     bin
@@ -19,7 +17,6 @@ path=(
 )
 export PATH
 
-# Various.
 export CLICOLOR=1
 export EDITOR=nvim
 export FZF_DEFAULT_COMMAND="rg --files"


### PR DESCRIPTION
Configure a shared gopls daemon by launching the same gopls binary with `-remote=auto`, resulting in but one `gopls serve` process.