### PR TITLE
Allow global test runner settings to be defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ let g:phpactorPhpBin = '/usr/local/bin/php'
 
 Implemented as a set of auto loaded functions in `autoload/test_runner.vim`, the test runner executes the current test case or test method (using [coc.nvim](https://github.com/neoclide/coc.nvim)) in the next available Tmux pane (through [Vimux](https://github.com/benmills/vimux)).
 
-Its behaviour is configured using these buffer level variables:
+Its behaviour is configured either using these buffer level variables:
 
 ```viml
 let b:test_runner_executable_case = 'runtests {file}'
@@ -95,6 +95,18 @@ let b:test_runner_executable_test = 'runtests {file} --filter={test}'
 
 " Optional lambda to translate buffer filename into actual test case name.
 let b:test_runner_filename_transformer = {file -> substitute(file, '/', '.', 'g')}
+```
+
+And/or using a global dictionary of settings, ordered by filetype:
+
+```viml
+let g:test_runner_settings = {
+    \ 'python': {
+        \ 'executable_case': 'runtests {file}',
+        \ 'executable_test': 'runtests {file} --filter={test}',
+        \ 'filename_transformer': {file -> substitute(file, '/', '.', 'g')}
+    \ }
+\ }
 ```
 
 Projects that require custom test configuration can configure these settings in a `.lvimrc` as well.

--- a/nvim/autoload/test_runner.vim
+++ b/nvim/autoload/test_runner.vim
@@ -1,12 +1,16 @@
+function! s:GetConfig(key, default) abort
+    return get(b:, 'test_runner_' . a:key, a:default)
+endfunction
+
 function! s:PrepareCommand(executable, file) abort
-    let l:Transformer = get(b:, 'test_runner_filename_transformer', {file -> file})
+    let l:Transformer = s:GetConfig('filename_transformer', {file -> file})
     let l:command = substitute(a:executable, '{file}', l:Transformer(a:file), 'g')
 
     return l:command
 endfunction
 
 function! test_runner#RunCase() abort
-    let l:executable = get(b:, 'test_runner_executable_case', '')
+    let l:executable = s:GetConfig('executable_case', '')
 
     if empty(l:executable)
         echomsg 'No case executable configured.'
@@ -19,7 +23,7 @@ function! test_runner#RunCase() abort
 endfunction
 
 function! test_runner#RunTest() abort
-    let l:executable = get(b:, 'test_runner_executable_test', '')
+    let l:executable = s:GetConfig('executable_test', '')
     let l:test_name = get(b:, 'coc_current_function', '')
 
     if empty(l:executable)

--- a/nvim/autoload/test_runner.vim
+++ b/nvim/autoload/test_runner.vim
@@ -1,5 +1,9 @@
 function! s:GetConfig(key, default) abort
-    return get(b:, 'test_runner_' . a:key, a:default)
+    let l:settings = get(g:, 'test_runner_settings', {})
+    let l:ft_settings = get(l:settings, &filetype, {})
+    let l:Default = get(l:ft_settings, a:key, a:default)
+
+    return get(b:, 'test_runner_' . a:key, l:Default)
 endfunction
 
 function! s:PrepareCommand(executable, file) abort


### PR DESCRIPTION
This allows test runner settings to be set in a global dictionary per filetype:

```viml
let g:test_runner_settings = {
    \ 'python': {
        \ 'executable_case': 'runtests {file}',
        \ 'executable_test': 'runtests {file} --filter={test}',
        \ 'filename_transformer': {file -> substitute(file, '/', '.', 'g')}
    \ }
\ }
```

Closes #98.