### PR TITLE
Use coc.nvim as provider for Neovim tags

### DIFF
--- a/nvim/ftplugin/go.vim
+++ b/nvim/ftplugin/go.vim
@@ -2,8 +2,6 @@
 let b:delimitMate_expand_space = 1
 let b:delimitMate_expand_cr = 1
 
-call ApplyCocDefinitionMappings()
-
 " Commands provided by vim-go.
 nmap <silent> <buffer> <Leader>gb <Plug>(go-build)
 nmap <silent> <buffer> <Leader>gc <Plug>(go-coverage-toggle)

--- a/nvim/ftplugin/javascript.vim
+++ b/nvim/ftplugin/javascript.vim
@@ -1,1 +1,0 @@
-call ApplyCocDefinitionMappings()

--- a/nvim/ftplugin/php.vim
+++ b/nvim/ftplugin/php.vim
@@ -18,8 +18,6 @@ augroup END
 let b:delimitMate_expand_space = 1
 let b:delimitMate_expand_cr = 1
 
-call ApplyCocDefinitionMappings()
-
 " Searching using ripgrep.
 nnoremap <silent> <buffer> <Leader>sce :execute "Rg \\bclass .+ (extends\|implements) .*\\b" . expand("<cword>") . "\\b"<CR>
 nnoremap <silent> <buffer> <Leader>sci :execute "Rg \\bnew\\s+" . expand("<cword>") . "\\b"<CR>

--- a/nvim/ftplugin/python.vim
+++ b/nvim/ftplugin/python.vim
@@ -13,8 +13,6 @@ if !empty(findfile('Pipfile.lock', '.;'))
     \ }
 endif
 
-call ApplyCocDefinitionMappings()
-
 nnoremap <silent> <buffer> <Leader>si :ALEFix isort<CR>
 
 " Searching using ripgrep.

--- a/nvim/ftplugin/typescript.vim
+++ b/nvim/ftplugin/typescript.vim
@@ -1,1 +1,0 @@
-call ApplyCocDefinitionMappings()

--- a/nvim/ftplugin/typescriptreact.vim
+++ b/nvim/ftplugin/typescriptreact.vim
@@ -1,1 +1,0 @@
-call ApplyCocDefinitionMappings()

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -125,6 +125,7 @@ set spelllang=en_gb
 set path=.,*
 set grepprg=rg\ --vimgrep
 set undofile
+set tagfunc=CocTagFunc
 
 " Colours
 set background=dark

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -287,15 +287,6 @@ inoremap <silent> <expr> <C-Space> coc#refresh()
 nnoremap <silent> <Leader>h :call CocActionAsync('doHover')<CR>
 nnoremap <silent> <Leader>ts :echo get(b:, 'coc_current_function', '')<CR>
 
-function! ApplyCocDefinitionMappings() abort
-    " Jump to definition.
-    nmap <silent> <buffer> <C-]> <Plug>(coc-definition)
-
-    " Jump to definition in split.
-    nnoremap <silent> <buffer> <C-W>] :call CocAction('jumpDefinition', 'vsplit')<CR>
-    nnoremap <silent> <buffer> <C-W><C-]> :call CocAction('jumpDefinition', 'vsplit')<CR>
-endfunction
-
 " Configure test runner.
 let g:test_runner_settings = {
     \ 'php': {


### PR DESCRIPTION
Using the new 'tagfunc' setting allows coc.nvim to provide the tags (if possible). When it doesn't yield any tags, it falls back to regular ctags generated ones.